### PR TITLE
refactor(): extracted stencil-router in app-routes component

### DIFF
--- a/src/components/app-routes/app-routes.tsx
+++ b/src/components/app-routes/app-routes.tsx
@@ -1,0 +1,27 @@
+import { Component } from '@stencil/core';
+
+@Component({
+  tag: 'app-routes'
+})
+export class AppRoutes {
+  render() {
+    return (
+      <stencil-router id='router'>
+        <stencil-route url={['/', '/news/:pageNum', '/news/:pageNum/']} component='news-page' exact={true}>
+        </stencil-route>
+
+        <stencil-route url='/show/:pageNum' component='show-page'>
+        </stencil-route>
+
+        <stencil-route url='/jobs/:pageNum' component='jobs-page'>
+        </stencil-route>
+
+        <stencil-route url='/ask/:pageNum' component='ask-page'>
+        </stencil-route>
+
+        <stencil-route url='/comments/:id' component='comments-page'>
+        </stencil-route>
+      </stencil-router>
+    );
+  }
+}

--- a/src/components/ionic-hn/ionic-hn.tsx
+++ b/src/components/ionic-hn/ionic-hn.tsx
@@ -1,6 +1,5 @@
 import { Component } from '@stencil/core';
 
-
 @Component({
   tag: 'ionic-hn',
   styleUrl: 'ionic-hn.scss'
@@ -61,22 +60,7 @@ export class IonicHn {
           </ion-toolbar>
         </ion-header>
 
-        <stencil-router id='router'>
-          <stencil-route url={['/', '/news/:pageNum', '/news/:pageNum/']} component='news-page' exact={true}>
-          </stencil-route>
-
-          <stencil-route url='/show/:pageNum' component='show-page'>
-          </stencil-route>
-
-          <stencil-route url='/jobs/:pageNum' component='jobs-page'>
-          </stencil-route>
-
-          <stencil-route url='/ask/:pageNum' component='ask-page'>
-          </stencil-route>
-
-          <stencil-route url='/comments/:id' component='comments-page'>
-          </stencil-route>
-        </stencil-router>
+        <app-routes></app-routes>
       </ion-app>
     );
   }

--- a/stencil.config.js
+++ b/stencil.config.js
@@ -1,6 +1,6 @@
 exports.config = {
   bundles: [
-    { components: ['ionic-hn', 'story-list', 'news-page'] },
+    { components: ['ionic-hn', 'story-list', 'news-page', 'app-routes'] },
     { components: ['show-page'] },
     { components: ['jobs-page'] },
     { components: ['ask-page'] },
@@ -20,4 +20,4 @@ exports.config = {
 exports.devServer = {
   root: 'www',
   watchGlob: '**/**'
-}
+};


### PR DESCRIPTION
I think it will be much cleaner to have all routes in one place and extend that component even more in the future by having more routes per module.
You can see the app here: https://ionic-hn.firebaseapp.com